### PR TITLE
Parameterised Contracts

### DIFF
--- a/Runtime/Contract.cs
+++ b/Runtime/Contract.cs
@@ -3,7 +3,34 @@ using System.Collections.Generic;
 namespace Contracts
 {
     /// <summary>
-    /// A promise-like contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
+    /// A parameterised contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
+    /// </summary>
+    /// <typeparam name="T">The type of data offered by the contract.</typeparam>
+    public class Contract<T> : Contract, IContract<T>
+    {
+        public T Offer { get; }
+
+        public Contract(Contract<T> contract)
+            : this(contract.Offer, contract.Fulfilling, contract.Rejecting) { }
+
+        public Contract(T offer, IContract contract)
+            : this(offer, contract.Fulfilling, contract.Rejecting) { }
+
+        public Contract(T offer, ICondition fulfilling)
+            : base(fulfilling)
+        {
+            Offer = offer;
+        }
+
+        public Contract(T offer, ICondition fulfilling, ICondition rejecting)
+            : base(fulfilling, rejecting)
+        {
+            Offer = offer;
+        }
+    }
+
+    /// <summary>
+    /// A contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
     /// </summary>
     public class Contract : ReadOnlyWatchable<ContractState>, IContract
     {
@@ -12,6 +39,9 @@ namespace Contracts
 
         private readonly ICondition rejecting;
         public ICondition Rejecting => rejecting;
+
+        public Contract(IContract other)
+            : this(other.Fulfilling, other.Rejecting) { }
 
         public Contract(ICondition fulfilling)
             : this(fulfilling, Condition.Never) { }
@@ -87,7 +117,15 @@ namespace Contracts
     }
 
     /// <summary>
-    /// Represents a promise-like contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
+    /// Represents a parameterised contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
+    /// </summary>
+    public interface IContract<T> : IContract
+    {
+        T Offer { get; }
+    }
+
+    /// <summary>
+    /// Represents a contract that is fulfilled when a fulfilling condition is met, or rejected when a rejecting condition is met (or both are met).
     /// </summary>
     public interface IContract : IReadOnlyWatchable<ContractState>
     {

--- a/Runtime/Scripting/CareerGraph/Nodes/ProgressionNode.cs
+++ b/Runtime/Scripting/CareerGraph/Nodes/ProgressionNode.cs
@@ -15,7 +15,7 @@ namespace Contracts.Scripting
 
         public IEnumerable<IContractBuilder> NextOnRejected { get; set; }
 
-        public IContract Build()
+        public virtual IContract Build()
         {
             Debug.Log($"Building {this}...");
             if (Contract == null)

--- a/Runtime/Scripting/CareerGraph/Nodes/StartNode.cs
+++ b/Runtime/Scripting/CareerGraph/Nodes/StartNode.cs
@@ -10,7 +10,7 @@ namespace Contracts.Scripting
     {
         public IEnumerable<IContractBuilderProgression> NextOnHired { get; set; }
 
-        public ICareer Build()
+        public virtual ICareer Build()
         {
             Debug.Log($"Building {this}...");
             return new Career(NextOnHired);

--- a/Runtime/Scripting/ContractGraph/Nodes/ConditionNode.cs
+++ b/Runtime/Scripting/ContractGraph/Nodes/ConditionNode.cs
@@ -10,7 +10,7 @@ namespace Contracts.Scripting
         [SerializeReference]
         public IConditionBuilder Builder;
 
-        public ICondition Build()
+        public virtual ICondition Build()
         {
             Debug.Log($"Building {this}...");
             if (Builder == null)

--- a/Runtime/Scripting/ContractGraph/Nodes/ContractNode.cs
+++ b/Runtime/Scripting/ContractGraph/Nodes/ContractNode.cs
@@ -10,7 +10,7 @@ namespace Contracts.Scripting
         public IConditionBuilder Fulfilling { get; set; }
         public IConditionBuilder Rejecting { get; set; }
 
-        public IContract Build()
+        public virtual IContract Build()
         {
             Debug.Log($"Building {this}...");
 


### PR DESCRIPTION
Implements parameterised contracts to make data association simpler since we will almost always want to have some kind of reward/punishment/hint associated with a contract. Copy constructors have been provided so that contracts can be built from other contracts, so it is simple to create parameterised contracts from non-parameterised, valueless contracts. Node build functions are now virtual so that they can be overridden with custom nodes that have custom data.